### PR TITLE
Mostly bugfixes

### DIFF
--- a/packages/save_vsr_300.yaml
+++ b/packages/save_vsr_300.yaml
@@ -3,11 +3,13 @@
 ################################################################################
 modbus:
   - name: VSR300
-    type: rtuovertcp
-    host: 192.168.88.15
-    port: 502
+    # See https://www.home-assistant.io/integrations/modbus/
+    type: rtuovertcp #User setting
+    host: 192.168.88.15 #User setting
+    port: 502  #User setting
     timeout: 3 #Timeout for slave response in seconds (default=3)
     delay: 3 #Time to sleep in seconds after connecting and before sending messages (defualt=0)
+    #message_wait_milliseconds: 50 #Increased to hopefully reduce errors in my serial comm (Default:30 for serial connection, 0 for all other connections.)
 
     climates:
       - name: vent_VSR300
@@ -251,12 +253,19 @@ modbus:
         offset: 0
         precision: 1
         data_type: uint16
+        scan_interval: 9
       - name: vsr300_countdown_mode_time_s
         #hub: VSR300
         slave: 1
         address: 1110
-        input_type: holding
+        input_type: input
         unit_of_measurement: s
+        data_type: uint16
+      - name: vsr300_countdown_mode_time_s_factor
+        #hub: VSR300
+        slave: 1
+        address: 1111
+        input_type: input
         data_type: uint16
       - name: vsr300_holiday_mode_duration
         #hub: VSR300
@@ -265,6 +274,7 @@ modbus:
         input_type: holding
         unit_of_measurement: days
         data_type: uint16
+        scan_interval: 9        
       - name: vsr300_away_mode_duration
         #hub: VSR300
         slave: 1
@@ -272,6 +282,7 @@ modbus:
         input_type: holding
         unit_of_measurement: h
         data_type: uint16
+        scan_interval: 9       
       - name: vsr300_fireplace_mode_duration
         #hub: VSR300
         slave: 1
@@ -279,6 +290,7 @@ modbus:
         input_type: holding
         unit_of_measurement: min
         data_type: uint16
+        scan_interval: 9        
       - name: vsr300_refresh_mode_duration
         #hub: VSR300
         slave: 1
@@ -286,6 +298,7 @@ modbus:
         input_type: holding
         unit_of_measurement: min
         data_type: uint16
+        scan_interval: 9        
       - name: vsr300_Crowded_mode_duration
         #hub: VSR300
         slave: 1
@@ -293,6 +306,7 @@ modbus:
         input_type: holding
         unit_of_measurement: h
         data_type: uint16
+        scan_interval: 9        
       - name: vsr300_moisture_extraction_sp
         #hub: VSR300
         device_class: humidity
@@ -487,7 +501,7 @@ input_number:
     min: 1
     max: 72
     step: 1
-    mode: slider
+    mode: box
     unit_of_measurement: h
     icon: mdi:timelapse
 
@@ -496,7 +510,7 @@ input_number:
     min: 1
     max: 240
     step: 1
-    mode: slider
+    mode: box
     unit_of_measurement: min
     icon: mdi:timelapse
 
@@ -505,7 +519,7 @@ input_number:
     min: 1
     max: 8
     step: 1
-    mode: slider
+    mode: box
     unit_of_measurement: h
     icon: mdi:timelapse
 
@@ -514,7 +528,7 @@ input_number:
     min: 1
     max: 60
     step: 1
-    mode: slider
+    mode: box
     unit_of_measurement: min
     icon: mdi:timelapse
 
@@ -667,15 +681,32 @@ sensor:
         friendly_name: "Time remaining when active - Holiday"
         value_template: >-
           {% if states('sensor.vsr300_mode_status_register')|int == 6 %}
-            {% set time = states('sensor.vsr300_countdown_mode_time_s') | int %}
-
+          
+            {% set time = states('sensor.vsr300_countdown_mode_time_s')|int + (states('sensor.vsr300_countdown_mode_time_s_factor')|int * 65535) %}
             {% set days = (time / 86400) | int %}
-              {%- if days > 0 -%}
-                {{ days }} days
-              {%- endif -%}
-           {% else %}
+            {% set hours = ((time % 86400) / 3600) | int %}
+            {% set minutes = ((time % 3600) / 60) | int %}
+
+            {%- if days > 0 -%}
+              {{ days }} days
+            {% else %}
+              {%- if time < 60 -%}
+                Less than 1 minute
+              {%- else -%}
+                {%- if hours > 0 -%}
+                  {{ hours }} h
+                {%- endif -%}
+                {%- if minutes > 0 -%}
+                  {%- if hours > 0 -%}
+                    {{ ' ' }}
+                  {%- endif -%}
+                  {{ minutes }} min
+                {%- endif -%}
+              {%- endif -%}   
+            {%- endif -%}
+          {% else %}
             Inactive
-          {% endif %}
+          {% endif %}      
 
       vsr300_summer_winter_operational_status:
         friendly_name: "Active season"
@@ -1269,66 +1300,98 @@ script:
       service: input_boolean.turn_off
       entity_id: input_boolean.vsr300_holiday_mode_status_dummy
 
-  vsr300_away_setpoint:
-    sequence:
-      - delay: "00:00:02"
-      - service: modbus.write_register
-        data_template:
-          hub: VSR300
-          unit: 1
-          address: 1102
-          value: 70
-
 automation:
-  - id: "vsr300getsetpoints"
-    alias: VSR300 Get setpoints
+  - id: "vsr300getsetpointeco"
+    alias: VSR300 Get setpoint Eco Heat offset
+    mode: restart
     description: ""
     trigger:
       - platform: state
         entity_id:
-          - sensor.vsr300_eco_heat_offset
-      - platform: state
-        entity_id:
-          - input_number.vsr300_away_mode_duration_sp
-      - platform: state
-        entity_id:
-          - input_number.vsr300_crowded_mode_duration_sp
-      - platform: state
-        entity_id:
-          - input_number.vsr300_fireplace_mode_duration_sp
-      - platform: state
-        entity_id:
-          - input_number.vsr300_holiday_mode_duration_sp
-      - platform: state
-        entity_id:
-          - input_number.vsr300_refresh_mode_duration_sp
+          - input_number.vsr300_eco_offset_temp_sp
     condition: []
     action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_eco_offset_temp_sp
           value: "{{ states('sensor.vsr300_eco_heat_offset') | int }}"
-        alias: Get setpoint eco offset temp
+        alias: Get setpoint eco offset temp        
+  - id: "vsr300getsetpointaway"
+    alias: VSR300 Get setpoint Away Duration
+    mode: restart
+    description: ""
+    trigger:        
+      - platform: state
+        entity_id:
+          - input_number.vsr300_away_mode_duration_sp
+    condition: []
+    action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_away_mode_duration_sp
           value: "{{ states('sensor.vsr300_away_mode_duration') | int }}"
         alias: Get setpoint away
+  - id: "vsr300getsetpointcrowded"
+    alias: VSR300 Get setpoint Crowded Duration
+    mode: restart
+    description: ""
+    trigger:           
+      - platform: state
+        entity_id:
+          - input_number.vsr300_crowded_mode_duration
+    condition: []
+    action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_crowded_mode_duration
           value: "{{ states('sensor.vsr300_crowded_mode_duration') | int }}"
         alias: Get setpoint crowded
+  - id: "vsr300getsetpointfireplace"
+    alias: VSR300 Get setpoint Fireplace Duration
+    mode: restart
+    description: ""
+    trigger:                   
+      - platform: state
+        entity_id:
+          - input_number.vsr300_fireplace_mode_duration_sp
+    condition: []
+    action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_fireplace_mode_duration_sp
           value: "{{ states('sensor.vsr300_fireplace_mode_duration') | int }}"
         alias: Get setpoint fireplace
+  - id: "vsr300getsetpointholiday"
+    alias: VSR300 Get setpoint Holiday Duration
+    mode: restart
+    description: ""
+    trigger:                            
+      - platform: state
+        entity_id:
+          - input_number.vsr300_holiday_mode_duration_sp
+    condition: []
+    action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_holiday_mode_duration_sp
           value: "{{ states('sensor.vsr300_holiday_mode_duration') | int }}"
         alias: Get setpoint holiday
+  - id: "vsr300getsetpointrefresh"
+    alias: VSR300 Get setpoint Refresh Duration
+    mode: restart
+    description: ""
+    trigger:                   
+      - platform: state
+        entity_id:
+          - input_number.vsr300_refresh_mode_duration_sp
+    condition: []
+    action:
+      - delay: "00:00:11"
       - service: input_number.set_value
         data_template:
           entity_id: input_number.vsr300_refresh_mode_duration_sp
@@ -1379,6 +1442,21 @@ automation:
           unit: 1
           address: 1102
           value: "{{ states.input_number.vsr300_fireplace_mode_duration_sp.state | int }}"
+          
+  - id: "vsr300SetSetpointAway"
+    alias: vsr300 Set Setpoint Away Mode
+    description: ""
+    trigger:
+      - platform: state
+        entity_id: input_number.vsr300_away_mode_duration_sp
+    condition: []
+    action:
+      - service: modbus.write_register
+        data_template:
+          hub: VSR300
+          unit: 1
+          address: 1101
+          value: "{{ states.input_number.vsr300_away_mode_duration_sp.state | int }}"          
 
   - id: "vsr300SetSetpointHoliday"
     alias: vsr300 Set Setpoint Holiday

--- a/packages/save_vsr_300.yaml
+++ b/packages/save_vsr_300.yaml
@@ -1558,7 +1558,6 @@ script:
 # Automation
 ################################################################################
 
->>>>>>> mainrepo/main
 automation:
   - id: "vsr300getsetpointeco"
     alias: VSR300 Get setpoint Eco Heat offset

--- a/packages/save_vsr_300.yaml
+++ b/packages/save_vsr_300.yaml
@@ -494,7 +494,7 @@ input_number:
   vsr300_refresh_mode_duration_sp:
     name: Refresh mode - Desired duration
     min: 1
-    max: 120
+    max: 240
     step: 1
     mode: slider
     unit_of_measurement: min


### PR DESCRIPTION
-There is a race condition with duration setpoints and their readbacks from Modbus. When making lots of changes, sometimes the setpoints get overwritten with an old value.
  -It's mostly fixed. But could be completely fixed by having separate readback and setpoint fields, but this would take extra UI space, and you don't change these often anyway.
  -Reduced the scan interval on duration settings to 9 s.
  -Added 11 s delay to sync of settings VSR->HA.
  -Made automations independent.
-Added back the comments on connection settings
-Fixed away mode setpoint
-Fixed countdown for holiday mode
-Changed input number sliders to boxes